### PR TITLE
fix accidental config.js contract name change

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-const CONTRACT_NAME = process.env.CONTRACT_NAME || 'mikedotdmg'; /* TODO: fill this in! */
+const CONTRACT_NAME = process.env.CONTRACT_NAME || 'wallet-example'; /* TODO: fill this in! */
 
 function getConfig(env) {
     switch (env) {


### PR DESCRIPTION
I accidentally committed my NEAR account instead of a generic name for the contract.